### PR TITLE
Xml read

### DIFF
--- a/docs/source_docs.rst
+++ b/docs/source_docs.rst
@@ -6,3 +6,4 @@ Source code documentation
    :caption: Contents
 
    xml_obj.rst
+   xml_collector.rst

--- a/docs/xml_collector.rst
+++ b/docs/xml_collector.rst
@@ -6,3 +6,9 @@ xml_collector.py
 TmcFile
 +++++++
 .. autoclass:: pytpy.TmcFile
+   :members:
+
+ElementCollector
+++++++++++++++++
+.. autoclass:: pytpy.xml_collector.ElementCollector
+   :members:

--- a/docs/xml_collector.rst
+++ b/docs/xml_collector.rst
@@ -1,0 +1,8 @@
+xml_collector.py
+================
+
+.. automodule:: pytpy.xml_collector
+
+TmcFile
++++++++
+.. autoclass:: pytpy.TmcFile

--- a/pytpy/__init__.py
+++ b/pytpy/__init__.py
@@ -3,6 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from .xml_obj import Symbol, DataType, SubItem
+from .xml_collector import TmcFile
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/pytpy/xml_collector.py
+++ b/pytpy/xml_collector.py
@@ -1,0 +1,14 @@
+"""
+xml_collector.py
+
+This file contains the objects for intaking TMC files and generating python
+interpretations. Db Files can be produced from the interpretation
+"""
+import logging
+logger = logging.getLogger(__name__)
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+
+
+class TmcFile:
+    pass

--- a/pytpy/xml_collector.py
+++ b/pytpy/xml_collector.py
@@ -82,7 +82,7 @@ class TmcFile:
 
         self.all_Symbols = ElementCollector()
         self.all_DataTypes = ElementCollector()
-        self.all_SubItems = ElementCollector() 
+        self.all_SubItems = defaultdict(ElementCollector) 
 
     def isolate_Symbols(self):
         '''
@@ -113,9 +113,9 @@ class TmcFile:
         )
         for xml_data_type in xml_data_types:
             data = DataType(xml_data_type)
-            if process_subitems:
-                self.isolate_SubItems(data)
             self.all_DataTypes.add(data)
+            if process_subitems:
+                self.isolate_SubItems(data.name)
 
     def isolate_SubItems(self,parent=None):
         '''
@@ -124,17 +124,25 @@ class TmcFile:
         
         Parameters
         ----------
-        parent : :class:`~DataType`
-            Specify which datatype to search for subitems. Subitems are
-            automatically linked to this parent datatype.
+        parent : :str
+            Specify the name string of the datatype to search for subitems.
+            Subitems are automatically linked to this parent datatype.
         '''
-        if type(parent) == DataType:
-            xml_subitems = parent.element.findall('./SubItem')
+        if type(parent) == str:
+            parent_obj = self.all_DataTypes[parent]
+            xml_subitems = parent_obj.element.findall('./SubItem')
             for xml_subitem in xml_subitems:
-                s_item = SubItem(xml_subitem,parent=parent)
-                self.all_SubItems.add(s_item)
+                s_item = SubItem(
+                    xml_subitem,
+                    parent=parent_obj
+                )
+                self.all_SubItems[parent].add(s_item)
 
 
         if type(parent) == ET.Element:
             pass
+
+    def isolate_all(self):
+        self.isolate_Symbols()
+        self.isolate_DataTypes()
 

--- a/pytpy/xml_collector.py
+++ b/pytpy/xml_collector.py
@@ -13,12 +13,39 @@ from pytpy import Symbol, DataType, SubItem
 
 
 class ElementCollector(dict):
+    '''
+    Dictionary-like object for controlling sets of insntances
+    :class:`~pytpy.Symbol`, :class:`~pytpy.DataType`, and
+    :class:`~pytpy.SubItem`. Each entry's key is the name of the TwinCAT
+    variable.  :func:`~pytpy.xml_collector.ElementCollector.add` automates this
+    setup and should be used to add entries instead of normal dictionary
+    insertion techniques. 
+    
+    Subclassed from python's standard dictionary.
+    '''
     def add(self, value):
+        '''
+        Include new item in the dictionary.
+
+        Parameters 
+        ----------
+        value : :class:`~pytpy.Symbol`, :class:`~pytpy.DataType`,or :class:`~pytpy.SubItem`.
+            The instance to add to the ElementCollector
+        '''
         name = value.name
         dict.__setitem__(self,name,value)
 
     @property
     def registered(self):
+        '''
+        Return subset of the dictionary including only items marked for pytpy's
+        comsumption with pragmas.
+
+        Returns
+        -------
+        dict
+            TwinCAT variables for pytpy
+        '''
         names = list(filter(
             lambda x: self[x].has_pragma,
             self,
@@ -29,6 +56,25 @@ class ElementCollector(dict):
 
 
 class TmcFile:
+    '''
+    Object for handling the reading comprehension comprehension of .tmc files.
+
+
+    Attributes
+    ----------
+    all_Symbols : :class:`~pytpy.xml_collector.ElementCollector`
+        Collection of all Symbols in the document. Must be initialized with
+        :func:`~isolate_Symbols`.
+    
+    all_DataTypes : :class:`~pytpy.xml_collector.ElementCollector`
+        Collection of all DataTypes in the document. Must be initialized with
+        :func:`~isolate_DataTypes`.
+        
+    all_SubItems : :class:`~pytpy.xml_collector.ElementCollector`
+        Collection of all SubItems in the document. Must be initialized with
+        :func:`~isolate_SubItems`.
+
+    '''
     def __init__(self, filename):
         self.filename = filename
         self.tree = ET.parse(self.filename)
@@ -39,6 +85,10 @@ class TmcFile:
         self.all_SubItems = ElementCollector() 
 
     def isolate_Symbols(self):
+        '''
+        Populate :attr:`~all_Symbols` with a :class:`~pytpy.Symbol` 
+        representing each symbol in the .tmc file.
+        '''
         data_area = self.root.find(
             "./Modules/Module/DataAreas/DataArea/[Name='PlcTask Internal']"
         )
@@ -48,6 +98,16 @@ class TmcFile:
             self.all_Symbols.add(sym)
 
     def isolate_DataTypes(self,process_subitems=True):
+        '''
+        Populate :attr:`~all_DataTypes` with a :class:`~pytpy.DataType` 
+        representing each DataType in the .tmc file.
+
+        Parameters
+        ----------
+        process_subitems : bool
+            If True, automatically process all subitems containted in the
+            datatypes populating :attr:`~all_SubItems`.
+        '''
         xml_data_types = self.root.findall(
             "./DataTypes/DataType"
         )
@@ -58,6 +118,16 @@ class TmcFile:
             self.all_DataTypes.add(data)
 
     def isolate_SubItems(self,parent=None):
+        '''
+        Populate :attr:`~all_SubItems` with a :class:`~pytpy.SubItem` 
+        representing each subitem in the .tmc file.
+        
+        Parameters
+        ----------
+        parent : :class:`~DataType`
+            Specify which datatype to search for subitems. Subitems are
+            automatically linked to this parent datatype.
+        '''
         if type(parent) == DataType:
             xml_subitems = parent.element.findall('./SubItem')
             for xml_subitem in xml_subitems:

--- a/pytpy/xml_collector.py
+++ b/pytpy/xml_collector.py
@@ -8,7 +8,63 @@ import logging
 logger = logging.getLogger(__name__)
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from pytpy import Symbol, DataType, SubItem
+
+
+
+class ElementCollector(dict):
+    def add(self, value):
+        name = value.name
+        dict.__setitem__(self,name,value)
+
+    @property
+    def registered(self):
+        names = list(filter(
+            lambda x: self[x].has_pragma,
+            self,
+
+        ))
+        return {name:self[name] for name in names}
+
 
 
 class TmcFile:
-    pass
+    def __init__(self, filename):
+        self.filename = filename
+        self.tree = ET.parse(self.filename)
+        self.root = self.tree.getroot()
+
+        self.all_Symbols = ElementCollector()
+        self.all_DataTypes = ElementCollector()
+        self.all_SubItems = ElementCollector() 
+
+    def isolate_Symbols(self):
+        data_area = self.root.find(
+            "./Modules/Module/DataAreas/DataArea/[Name='PlcTask Internal']"
+        )
+        xml_symbols = data_area.findall('./Symbol')
+        for xml_symbol in xml_symbols:
+            sym = Symbol(xml_symbol)
+            self.all_Symbols.add(sym)
+
+    def isolate_DataTypes(self,process_subitems=True):
+        xml_data_types = self.root.findall(
+            "./DataTypes/DataType"
+        )
+        for xml_data_type in xml_data_types:
+            data = DataType(xml_data_type)
+            if process_subitems:
+                self.isolate_SubItems(data)
+            self.all_DataTypes.add(data)
+
+    def isolate_SubItems(self,parent=None):
+        if type(parent) == DataType:
+            xml_subitems = parent.element.findall('./SubItem')
+            for xml_subitem in xml_subitems:
+                s_item = SubItem(xml_subitem,parent=parent)
+                self.all_SubItems.add(s_item)
+
+
+        if type(parent) == ET.Element:
+            pass
+

--- a/pytpy/xml_obj.py
+++ b/pytpy/xml_obj.py
@@ -92,6 +92,7 @@ class BaseElement:
         dict()
             Dictionary. The key is the property name and the value is a list of
             values found in the xml
+
         """
         props = self.properties
         pragmas = defaultdict(list)
@@ -100,6 +101,19 @@ class BaseElement:
                 pragmas[entry] = props.get(entry)
 
         return pragmas
+
+    @property
+    def has_pragma(self):
+        '''
+        Returns
+        -------
+        bool
+            True if there are regestered pragmas attached to this xml element
+        '''
+        if len(self.pragmas) > 0:
+            return True
+
+        return False
 
     def _get_raw_parent(self):
         '''
@@ -142,7 +156,6 @@ class BaseElement:
                 and type(other) != Symbol
                 and type(other) != DataType
                 and type(other) != SubItem):
-            print("type trigger",type(other))
             return False
         if self.element == other.element:
             return True
@@ -173,6 +186,7 @@ class BaseElement:
             The name of the variable
         '''
         return self.get_subfield("Name").text
+
 
 class Symbol(BaseElement):
     '''

--- a/pytpy/xml_obj.py
+++ b/pytpy/xml_obj.py
@@ -115,12 +115,6 @@ class BaseElement:
 
         return False
 
-    def _get_raw_parent(self):
-        '''
-        slated for removal
-        '''
-        return self.element.find('.')
-
     def get_subfield(self, field_target, get_all=False):
         """
         Produce element(s) within the class instance's target element. If

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,9 @@ def generic_tmc_root():
     tree = ET.parse(test_path)
     root = tree.getroot()
     return root
+
+@pytest.fixture(scope='function')
+def generic_tmc_path():
+    directory = os.path.dirname(os.path.realpath(__file__))
+    test_path = os.path.join(directory, "generic.tmc")
+    return test_path

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -42,7 +42,6 @@ def test_ElementCollector_add(generic_tmc_root):
     assert col['VERSION'] == version 
 
 
-
 def test_ElementCollector_registered(generic_tmc_root):
     root = generic_tmc_root
     iterator = DataType(root.find("./DataTypes/DataType/[Name='iterator']"))
@@ -56,7 +55,6 @@ def test_ElementCollector_registered(generic_tmc_root):
     print(col['VERSION'].pragmas)
     assert col['iterator'].pragmas == {'iterator attr':['42']}
     assert col.registered == {'iterator':iterator}
-
 
 
 def test_TmcFile_instantiation(generic_tmc_path,generic_tmc_root):
@@ -78,6 +76,7 @@ def test_TmcFile_isolate_Symbols(generic_tmc_path):
 
     assert len(tmc.all_Symbols) == 18
 
+
 def test_TmcFile_isolate_DataTypes(generic_tmc_path):
     tmc = TmcFile(generic_tmc_path)
     tmc.isolate_DataTypes()
@@ -87,16 +86,53 @@ def test_TmcFile_isolate_DataTypes(generic_tmc_path):
 
     assert len(tmc.all_DataTypes) == 7
 
+
 def test_TmcFile_isolate_SubItems(generic_tmc_path):
     tmc = TmcFile(generic_tmc_path)
     tmc.isolate_DataTypes(process_subitems=False)
-    tmc.isolate_SubItems(tmc.all_DataTypes['iterator'])
+    tmc.isolate_SubItems('iterator')
 
-    assert 'increment' in tmc.all_SubItems
-    assert 'out' in tmc.all_SubItems
-    assert 'value' in tmc.all_SubItems
-    assert 'lim' in tmc.all_SubItems
+    assert 'increment' in tmc.all_SubItems['iterator']
+    assert 'out' in tmc.all_SubItems['iterator']
+    assert 'value' in tmc.all_SubItems['iterator']
+    assert 'lim' in tmc.all_SubItems['iterator']
    
-    assert len(tmc.all_SubItems) == 4
+    assert len(tmc.all_SubItems['iterator']) == 4
+
+
+
+
+def test_TmcFile_isolate_all(generic_tmc_path):
+    tmc = TmcFile(generic_tmc_path)
+    tmc.isolate_all()
+    
+    assert "MAIN.ulimit" in tmc.all_Symbols
+    assert "MAIN.count" in tmc.all_Symbols
+    assert "MAIN.NEW_VAR" in tmc.all_Symbols
+    assert "MAIN.test_iterator" in tmc.all_Symbols
+    assert "Constants.RuntimeVersion" in tmc.all_Symbols
+
+    assert len(tmc.all_Symbols) == 18
+
+
+    assert "iterator" in tmc.all_DataTypes
+    assert "VERSION" in tmc.all_DataTypes
+
+    assert len(tmc.all_DataTypes) == 7
+
+    '''
+    for x in tmc.all_DataTypes:
+        print("\t",x,"  ", len(tmc.all_DataTypes[x].children))
+        for y in tmc.all_DataTypes[x].children:
+            print("\t\t",y)
+    '''
+
+    assert 'increment' in tmc.all_SubItems['iterator']
+    assert 'out' in tmc.all_SubItems['iterator']
+    assert 'value' in tmc.all_SubItems['iterator']
+    assert 'lim' in tmc.all_SubItems['iterator']
+   
+    assert len(tmc.all_SubItems['iterator']) == 4
+
 
 

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -1,0 +1,20 @@
+import pytest
+import logging
+
+import xml.etree.ElementTree as ET
+
+#from pytpy.xml_obj import Symbol, DataType
+from pytpy import Symbol, DataType, SubItem
+from pytpy.xml_obj import BaseElement
+
+from pytpy import TmcFile 
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+
+def test_TmcFile_instantiation():
+    try:
+        tmc = TmcFile()
+    except:
+        pytest.fail("Instantiation of TmcFile should not generate errors")

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -7,14 +7,96 @@ import xml.etree.ElementTree as ET
 from pytpy import Symbol, DataType, SubItem
 from pytpy.xml_obj import BaseElement
 
-from pytpy import TmcFile 
+from pytpy import TmcFile
+from pytpy.xml_collector import ElementCollector
+
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
 
-def test_TmcFile_instantiation():
+
+def test_ElementCollector_instantiation(generic_tmc_root):
     try:
-        tmc = TmcFile()
+        col = ElementCollector()
+    except:
+        pytest.fail(
+            "Instantiation of XmlObjCollector should not generate errors"
+        )
+
+
+def test_ElementCollector_add(generic_tmc_root):
+    root = generic_tmc_root
+    iterator = DataType(root.find("./DataTypes/DataType/[Name='iterator']"))
+    version = DataType(root.find("./DataTypes/DataType/[Name='VERSION']"))
+    col = ElementCollector()
+    col.add(iterator)
+    col.add(version)
+    assert 'iterator' in col
+    assert 'VERSION' in col
+    
+    col.add(version)
+    assert len(col) == 2
+    
+    assert col['iterator'] == iterator
+    assert col['VERSION'] == version 
+
+
+
+def test_ElementCollector_registered(generic_tmc_root):
+    root = generic_tmc_root
+    iterator = DataType(root.find("./DataTypes/DataType/[Name='iterator']"))
+    iterator.registered_pragmas.append("iterator attr")
+    version = DataType(root.find("./DataTypes/DataType/[Name='VERSION']"))
+    col = ElementCollector()
+    col.add(iterator)
+    col.add(version)
+
+    print(col['iterator'].pragmas)
+    print(col['VERSION'].pragmas)
+    assert col['iterator'].pragmas == {'iterator attr':['42']}
+    assert col.registered == {'iterator':iterator}
+
+
+
+def test_TmcFile_instantiation(generic_tmc_path,generic_tmc_root):
+    try:
+        tmc = TmcFile(generic_tmc_path)
     except:
         pytest.fail("Instantiation of TmcFile should not generate errors")
+
+
+def test_TmcFile_isolate_Symbols(generic_tmc_path):
+    tmc = TmcFile(generic_tmc_path)
+    tmc.isolate_Symbols()
+
+    assert "MAIN.ulimit" in tmc.all_Symbols
+    assert "MAIN.count" in tmc.all_Symbols
+    assert "MAIN.NEW_VAR" in tmc.all_Symbols
+    assert "MAIN.test_iterator" in tmc.all_Symbols
+    assert "Constants.RuntimeVersion" in tmc.all_Symbols
+
+    assert len(tmc.all_Symbols) == 18
+
+def test_TmcFile_isolate_DataTypes(generic_tmc_path):
+    tmc = TmcFile(generic_tmc_path)
+    tmc.isolate_DataTypes()
+
+    assert "iterator" in tmc.all_DataTypes
+    assert "VERSION" in tmc.all_DataTypes
+
+    assert len(tmc.all_DataTypes) == 7
+
+def test_TmcFile_isolate_SubItems(generic_tmc_path):
+    tmc = TmcFile(generic_tmc_path)
+    tmc.isolate_DataTypes(process_subitems=False)
+    tmc.isolate_SubItems(tmc.all_DataTypes['iterator'])
+
+    assert 'increment' in tmc.all_SubItems
+    assert 'out' in tmc.all_SubItems
+    assert 'value' in tmc.all_SubItems
+    assert 'lim' in tmc.all_SubItems
+   
+    assert len(tmc.all_SubItems) == 4
+
+


### PR DESCRIPTION
Add TmcFile and ElementCollector. TmcFile represents the overall structure of the TwinCAT's tmc out put by organizing the relationships between the python representations. ElementCollector provides tools for organizing python representations within TmcFile more easily.